### PR TITLE
Change: Adjust running mypy in ci-python workflow

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -20,7 +20,7 @@ on:
         type: string
       test-command:
         description: "Command to run the unit tests"
-        default: python -m unittest -v
+        default: "python -m unittest -v"
         type: string
 
 jobs:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -10,6 +10,10 @@ on:
         description: "Check types with mypy"
         default: true
         type: boolean
+      mypy-arguments:
+        description: "Additional arguments to mypy"
+        default: ""
+        type: string
       python-version:
         description: "Python version to use"
         default: "3.10"
@@ -69,5 +73,5 @@ jobs:
       - name: Run mypy
         uses: greenbone/actions/mypy-python@v2
         with:
-          packages: ${{ inputs.lint-packages }}
+          mypy-arguments: ${{ inputs.mypy-arguments }}
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/codecov-python.yml
+++ b/.github/workflows/codecov-python.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install and calculate and upload coverage to codecov.io
         uses: greenbone/actions/coverage-python@v2
         with:
-          python-version: "3.10"
+          python-version: ${{ inputs.python-version }}
           cache: "true"
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Greenbone projects
 
 - [Workflows](#workflows)
   - [Convention Commits](#convention-commits)
+  - [CI Python](#ci-python)
+  - [Deploy on PyPI](#deploy-on-pypi)
+  - [Codecov Python](#codecov-python)
+  - [Release Python](#release-python)
 - [Support](#support)
 - [Maintainer](#maintainer)
 - [License](#license)
@@ -39,6 +43,136 @@ Inputs:
 | Name | Description | |
 |------|-------------|-|
 | ignore-actors | A comma separated list of users to ignore PRs from | Optional |
+
+### CI Python
+
+A workflow to lint, test and check Python projects.
+
+```yaml
+name: Check Python project
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint-and-test:
+    strategy:
+      matrix:
+        python-version:
+            - "3.9"
+            - "3.10"
+            - "3.11"
+
+    name: Lint and test
+    uses: greenbone/workflows/.github/workflows/ci-python.yml@main
+    with:
+      lint-packages: my-python-package
+      python-version: ${{ matrix.python-version }}
+```
+
+Inputs:
+
+| Name | Description | |
+|------|-------------|-|
+| lint-packages | Names of the Python packages to be linted | |
+| mypy | Check types with mypy | Optional (default: true) |
+| mypy-arguments | Additional arguments for mypy | Optional |
+| python-version | Python version to use | Optional (default: `"3.10"`) |
+| test-command | Command to run the unit tests | Optional (default: `"python -m unittest -v"`) |
+
+### Deploy on PyPI
+
+A workflow to deploy a Python package on [PyPI](https://www.pypi.org).
+
+```yml
+name: Deploy on PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    uses: greenbone/workflows/.github/workflows/deploy-pypi.yml@main
+    secrets: inherit
+```
+
+Secrets:
+
+| Name | Description | |
+|------|-------------|-|
+| PYPI_TOKEN | Token with permissions to upload the package to PyPI | Required |
+
+### Codecov Python
+
+Calculate coverage and upload it to to [codecov.io](https://codecov.io).
+
+```yml
+name: Code Coverage
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  codecov:
+    name: Upload coverage to codecov.io
+    uses: greenbone/workflows/.github/workflows/codecov-python.yml@main
+    secrets: inherit
+```
+
+Secrets:
+
+| Name | Description | |
+|------|-------------|-|
+| CODECOV_TOKEN | Token for uploading coverage reports to codecov.io | Optional |
+
+Inputs:
+
+| Name | Description | |
+|------|-------------|-|
+| python-version | Python version to use | Optional (default: `"3.10"`) |
+
+### Release Python
+
+A workflow to create GitHub releases for Python projects.
+
+```yml
+name: Release Python package
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Create a new CalVer release
+    uses: greenbone/workflows/.github/workflows/release-python.yml@main
+    secrets: inherit
+```
+
+Secrets:
+
+| Name | Description | |
+|------|-------------|-|
+| GREENBONE_BOT | Username of the Greenbone Bot Account | Required |
+| GREENBONE_BOT_TOKEN | Token for creating a GitHub release | Required |
+| GREENBONE_BOT_MAIL | Email Address of the Greenbone Bot Account for git commits | Required |
+| GPG_KEY | GPG key to sign the release files | Optional |
+| GPG_FINGERPRINT | Fingerprint of the GPG key | Required if `GPG_KEY` is set |
+| GPG_PASSPHRASE | Passphrase for the GPG key | Required if `GPG_KEY` is set |
+
+Inputs:
+
+| Name | Description | |
+|------|-------------|-|
+| release-type | Type of the release | Optional (default: `"calendar"`) |
 
 ## Support
 


### PR DESCRIPTION

## What

Adjust running mypy in ci-python workflow

## Why
Allow to pass additional arguments to the mypy type checking job. By default this should not be necessary and all mypy settings should be included in the pyproject.toml file.

## References

Requires https://github.com/greenbone/actions/pull/627
