### PR TITLE
Change: Split CI Python workflow into sub-workflows

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -1,0 +1,25 @@
+name: Check project versioning
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python version to use"
+        default: "3.10"
+        type: string
+
+jobs:
+  check-version:
+    name: Check versioning for consistency
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install python, poetry and dependencies
+        uses: greenbone/actions/poetry@v2
+        with:
+          python-version: ${{ inputs.python-version }}
+          cache: "true"
+          cache-poetry-installation: "true"
+      - name: Check version
+        run: |
+          poetry run pontos-version verify current

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,4 +1,4 @@
-name: Build and test
+name: Check and test
 
 on:
   workflow_call:
@@ -6,10 +6,6 @@ on:
       lint-packages:
         description: "Names of the Python packages to be linted"
         type: string
-      mypy:
-        description: "Check types with mypy"
-        default: true
-        type: boolean
       mypy-arguments:
         description: "Additional arguments to mypy"
         default: ""
@@ -26,52 +22,21 @@ on:
 jobs:
   linting:
     name: Linting
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install and check with black, pylint and pontos.version
-        uses: greenbone/actions/lint-python@v2
-        with:
-          packages: ${{ inputs.lint-packages }}
-          python-version: ${{ inputs.python-version }}
-          cache: "true"
+    uses: ./.github/workflows/lint-python.yml
+    with:
+      lint-packages: ${{ inputs.lint-packages }}
+      python-version: ${{ inputs.python-version }}
 
   test:
-    name: Run all tests
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install python, poetry and dependencies
-        uses: greenbone/actions/poetry@v2
-        with:
-          python-version: ${{ inputs.python-version }}
-          cache: "true"
-          cache-poetry-installation: "true"
-      - name: Run unit tests
-        run: poetry run ${{ inputs.test-command }}
-
-  check-version:
-    name: Check versioning for consistency
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install python, poetry and dependencies
-        uses: greenbone/actions/poetry@v2
-        with:
-          cache: "true"
-          cache-poetry-installation: "true"
-      - name: Check version
-        run: |
-          poetry run pontos-version verify current
+    name: Run tests
+    uses: ./.github/workflows/test-python.yml
+    with:
+      python-version: ${{ inputs.python-version }}
+      test-command: ${{ inputs.test-command }}
 
   mypy:
     name: Check type information
-    if: inputs.mypy
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run mypy
-        uses: greenbone/actions/mypy-python@v2
-        with:
-          mypy-arguments: ${{ inputs.mypy-arguments }}
-          python-version: ${{ inputs.python-version }}
+    uses: ./.github/workflows/typing-python.yml
+    with:
+      mypy-arguments: ${{ inputs.mypy-arguments }}
+      python-version: ${{ inputs.python-version }}

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,0 +1,25 @@
+name: Lint Python package
+
+on:
+  workflow_call:
+    inputs:
+      lint-packages:
+        description: "Names of the Python packages to be linted"
+        type: string
+      python-version:
+        description: "Python version to use"
+        default: "3.10"
+        type: string
+
+jobs:
+  linting:
+    name: Linting
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install and check with black, pylint and pontos.version
+        uses: greenbone/actions/lint-python@v2
+        with:
+          packages: ${{ inputs.lint-packages }}
+          python-version: ${{ inputs.python-version }}
+          cache: "true"

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,0 +1,28 @@
+name: Test Python package
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python version to use"
+        default: "3.10"
+        type: string
+      test-command:
+        description: "Command to run the unit tests"
+        default: "python -m unittest -v"
+        type: string
+
+jobs:
+  test:
+    name: Run all tests
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install python, poetry and dependencies
+        uses: greenbone/actions/poetry@v2
+        with:
+          python-version: ${{ inputs.python-version }}
+          cache: "true"
+          cache-poetry-installation: "true"
+      - name: Run unit tests
+        run: poetry run ${{ inputs.test-command }}

--- a/.github/workflows/typing-python.yml
+++ b/.github/workflows/typing-python.yml
@@ -1,0 +1,27 @@
+name: Check Python package type hints
+
+
+on:
+  workflow_call:
+    inputs:
+      mypy-arguments:
+        description: "Additional arguments to mypy"
+        default: ""
+        type: string
+      python-version:
+        description: "Python version to use"
+        default: "3.10"
+        type: string
+
+jobs:
+  mypy:
+    name: Check type information
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run mypy
+        uses: greenbone/actions/mypy-python@v2
+        with:
+          mypy-arguments: ${{ inputs.mypy-arguments }}
+          python-version: ${{ inputs.python-version }}
+          cache: "true"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Greenbone projects
 
 - [Workflows](#workflows)
   - [Convention Commits](#convention-commits)
+  - [Check Versioning](#check-versioning)
+  - [Lint Python](#lint-python)
+  - [Test Python](#test-python)
+  - [Typing Python](#typing-python)
   - [CI Python](#ci-python)
   - [Deploy on PyPI](#deploy-on-pypi)
   - [Codecov Python](#codecov-python)
@@ -47,9 +51,100 @@ Inputs:
 |------|-------------|-|
 | ignore-actors | A comma separated list of users to ignore PRs from | Optional |
 
+### Check Versioning
+
+A workflow to check for consistent versioning in a project.
+
+```yml
+name: Check versioning
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  versioning:
+    uses: greenbone/workflows/.github/workflows/check-version.yml@main
+```
+
+| Name | Description | |
+|------|-------------|-|
+| python-version | Python version to use | Optional (default: `"3.10"`) |
+
+### Lint Python
+
+A workflow to lint Python project via pylint.
+
+```yml
+name: Lint Python project
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  linting:
+    uses: greenbone/workflows/.github/workflows/lint-python.yml@main
+```
+
+| Name | Description | |
+|------|-------------|-|
+| python-version | Python version to use | Optional (default: `"3.10"`) |
+| lint-packages | Names of the Python packages to be linted | |
+
+### Test Python
+
+A workflow to run tests of a Python project.
+
+```yml
+name: Test Python project
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  linting:
+    uses: greenbone/workflows/.github/workflows/test-python.yml@main
+```
+
+| Name | Description | |
+|------|-------------|-|
+| python-version | Python version to use | Optional (default: `"3.10"`) |
+| test-command | Command to run the unit tests | Optional (default: `"python -m unittest -v"`) |
+
+### Typing Python
+
+A workflow to check the type hints of a Python project via mypy.
+
+```yml
+name: Check type hints
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  linting:
+    uses: greenbone/workflows/.github/workflows/typing-python.yml@main
+```
+
+| Name | Description | |
+|------|-------------|-|
+| python-version | Python version to use | Optional (default: `"3.10"`) |
+| mypy-arguments | Additional arguments for mypy | Optional |
+
 ### CI Python
 
-A workflow to lint, test and check Python projects.
+A workflow to lint, test and type check Python projects.
 
 ```yaml
 name: Check Python project
@@ -80,10 +175,9 @@ Inputs:
 
 | Name | Description | |
 |------|-------------|-|
-| lint-packages | Names of the Python packages to be linted | |
-| mypy | Check types with mypy | Optional (default: true) |
-| mypy-arguments | Additional arguments for mypy | Optional |
 | python-version | Python version to use | Optional (default: `"3.10"`) |
+| lint-packages | Names of the Python packages to be linted | |
+| mypy-arguments | Additional arguments for mypy | Optional |
 | test-command | Command to run the unit tests | Optional (default: `"python -m unittest -v"`) |
 
 ### Deploy on PyPI


### PR DESCRIPTION


## What

Split CI Python workflow into sub-workflows
## Why
This allows to re-use parts of the CI workflows more easily. For example we have projects using a different linter.