### PR TITLE
Allow to set linter for corresponding Python workflows

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -11,12 +11,16 @@ on:
         default: ""
         type: string
       python-version:
-        description: "Python version to use"
+        description: "Python version to use. Default is Python '3.10'."
         default: "3.10"
         type: string
       test-command:
-        description: "Command to run the unit tests"
+        description: "Command to run the unit tests. Default is 'python -m unittest -v'."
         default: "python -m unittest -v"
+        type: string
+      linter:
+        description: "Linter to use: Default is 'pylint'."
+        default: "pylint"
         type: string
 
 jobs:
@@ -26,6 +30,7 @@ jobs:
     with:
       lint-packages: ${{ inputs.lint-packages }}
       python-version: ${{ inputs.python-version }}
+      linter: ${{ inputs.linter }}
 
   test:
     name: Run tests

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -7,8 +7,12 @@ on:
         description: "Names of the Python packages to be linted"
         type: string
       python-version:
-        description: "Python version to use"
+        description: "Python version to use. Default is Python '3.10'."
         default: "3.10"
+        type: string
+      linter:
+        description: "Linter to use: Default is 'pylint'."
+        default: "pylint"
         type: string
 
 jobs:
@@ -22,4 +26,5 @@ jobs:
         with:
           packages: ${{ inputs.lint-packages }}
           python-version: ${{ inputs.python-version }}
+          linter: ${{ inputs.linter }}
           cache: "true"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ jobs:
 |------|-------------|-|
 | python-version | Python version to use | Optional (default: `"3.10"`) |
 | lint-packages | Names of the Python packages to be linted | |
+| linter | Linter to use | Optional (default: `"pylint"`) |
 
 ### Test Python
 
@@ -181,6 +182,7 @@ Inputs:
 | lint-packages | Names of the Python packages to be linted | |
 | mypy-arguments | Additional arguments for mypy | Optional |
 | test-command | Command to run the unit tests | Optional (default: `"python -m unittest -v"`) |
+| linter | Linter to use | Optional (default: `"pylint"`) |
 
 ### Deploy on PyPI
 


### PR DESCRIPTION

## What

Allow to set linter for corresponding Python workflows

## Why

This will allow to use ruff in conjunction with our CI workflows.
