### PR TITLE
Add: Extend `git-tag-prefix` input to all release workflows

### DIFF
--- a/.github/workflows/release-3rd-gen.yml
+++ b/.github/workflows/release-3rd-gen.yml
@@ -3,6 +3,10 @@ name: Release 3rd Gen
 on:
   workflow_call:
     inputs:
+      git-tag-prefix:
+        description: "Set git tag prefix to the passed input. Default: ''"
+        default: "v"
+        type: string
       release-type:
         description: "Release type. One of alpha, patch, minor, major, release-candidate"
         type: string

--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -3,15 +3,15 @@ name: Release Cloud
 on:
   workflow_call:
     inputs:
+      git-tag-prefix:
+        description: "Set git tag prefix to the passed input. Default: ''"
+        default: ""
+        type: string
       release-type:
         description: "Release type. One of alpha, patch, minor, major, release-candidate"
         type: string
       release-version:
         description: "Set an explicit version, that will overwrite release-type. Fails if version is not compliant."
-        type: string
-      git-tag-prefix:
-        description: "Set git tag prefix to the passed input. Default: ''"
-        default: ""
         type: string
     secrets:
       GREENBONE_BOT:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -3,6 +3,10 @@ name: Release Python package
 on:
   workflow_call:
     inputs:
+      git-tag-prefix:
+        description: "Set git tag prefix to the passed input. Default: ''"
+        default: "v"
+        type: string
       release-type:
         default: "calendar"
         type: string
@@ -39,6 +43,7 @@ jobs:
       - name: Release with release action
         uses: greenbone/actions/release@v2
         with:
+          git-tag-prefix: ${{ inputs.git-tag-prefix }}
           github-user: ${{ secrets.GREENBONE_BOT }}
           github-user-mail: ${{ secrets.GREENBONE_BOT_MAIL }}
           github-user-token: ${{ secrets.GREENBONE_BOT_TOKEN }}


### PR DESCRIPTION
## What
Extend `git-tag-prefix` input to all release workflows
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

will make `pontos` default to `""`

<!-- Describe why are these changes necessary? -->

## References
DEVOPS-733
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


