### PR TITLE
Add: helm-container-build-push-3rd-gen and helm-build-push-3rd-gen

### DIFF
--- a/.github/workflows/helm-build-push-3rd-gen.yml
+++ b/.github/workflows/helm-build-push-3rd-gen.yml
@@ -1,0 +1,58 @@
+name: Helm chart release on tag
+
+on:
+  workflow_call:
+    inputs:
+      chart:
+        description: "The name of the helm chart to update."
+        required: true
+      container-digest:
+        description: "The container digest for the helm chart tag."
+        required: true
+    secrets:
+      GREENBONE_BOT:
+        required: true
+      GREENBONE_BOT_PACKAGES_WRITE_TOKEN:
+        required: true
+      GREENBONE_BOT_TOKEN:
+        required: true
+
+jobs:
+  release-helm-chart:
+    name: Release helm chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Get version from tag
+        id: version
+        run: |
+          vtag='${{ github.ref_name }}'
+          echo "tag=${vtag:1}" >> $GITHUB_OUTPUT
+      - name: Run helm version upgrade
+        uses: greenbone/actions/helm-version-upgrade@v3
+        with:
+          chart-path: ${{ github.workspace }}/charts/${{ inputs.chart }}
+          chart-version: ${{ steps.version.outputs.tag }}
+          image-tag: "${{ steps.version.outputs.tag }}@${{ inputs.container-digest }}"
+      - name: Print Chart.yaml
+        run: |
+          cat '${{ github.workspace }}/charts/${{ inputs.chart }}/Chart.yaml'
+      - name: Print values.yaml
+        run: |
+          cat '${{ github.workspace }}/charts/${{ inputs.chart }}/values.yaml'
+      - name: Upload to github registry
+        uses: greenbone/actions/helm-build-push@v3
+        with:
+          chart-name: ${{ inputs.chart }}
+          registry: ${{ vars.IMAGE_REGISTRY }}
+          registry-subpath: helm-charts/
+          registry-user: ${{ secrets.GREENBONE_BOT }}
+          registry-token: ${{ secrets.GREENBONE_BOT_PACKAGES_WRITE_TOKEN }}
+      - name: Trigger product helm chart upgrade
+        uses: greenbone/actions/trigger-workflow@v3
+        with:
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
+          repository: "greenbone/product-helm-chart"
+          workflow: product-chart-upgrade.yml
+          inputs: '{"chart": "${{ inputs.chart }}", "tag": "${{ github.ref_name }}"}'

--- a/.github/workflows/helm-build-push-3rd-gen.yml
+++ b/.github/workflows/helm-build-push-3rd-gen.yml
@@ -5,9 +5,11 @@ on:
     inputs:
       chart:
         description: "The name of the helm chart to update."
+        type: string
         required: true
       container-digest:
         description: "The container digest for the helm chart tag."
+        type: string
         required: true
     secrets:
       GREENBONE_BOT:

--- a/.github/workflows/helm-build-push-3rd-gen.yml
+++ b/.github/workflows/helm-build-push-3rd-gen.yml
@@ -1,4 +1,4 @@
-name: Helm chart release on tag
+name: Helm chart release on tag 3rd gen
 
 on:
   workflow_call:

--- a/.github/workflows/helm-container-build-push-3rd-gen.yml
+++ b/.github/workflows/helm-container-build-push-3rd-gen.yml
@@ -65,5 +65,5 @@ jobs:
     uses: greenbone/workflows/.github/workflows/helm-build-push-3rd-gen.yml@main
     with:
       chart: ${{ inputs.helm-chart }}
-      container-digest: ${{ needs.build-and-push.outputs.digest }}
+      container-digest: ${{ needs.building-container.outputs.digest }}
     secrets: inherit

--- a/.github/workflows/helm-container-build-push-3rd-gen.yml
+++ b/.github/workflows/helm-container-build-push-3rd-gen.yml
@@ -6,24 +6,31 @@ on:
       build-context:
         description: "Path to image build context. Default: ."
         default: .
+        type: string
       build-docker-file:
         description: "Path to the docker file. Default: ./Dockerfile"
         default: ./Dockerfile
+        type: string
       build-args:
         description: "Use these build-args for the docker build process. It is not possible to use secrets in here! Use the action."
         default: ""
+        type: string
       helm-chart:
         description: "The name of the helm chart to update. If not set, no chart update will be done. Default: empty"
         default: ""
+        type: string
       image-labels:
         description: "Image labels."
         required: true
+        type: string
       image-url:
         description: "Image url/name without registry."
         required: true
+        type: string
       image-platforms:
         description: "Image platforms to build for. Default: linux/amd64"
         default: linux/amd64
+        type: string
     secrets:
       COSIGN_KEY_OPENSIGHT:
         required: true

--- a/.github/workflows/helm-container-build-push-3rd-gen.yml
+++ b/.github/workflows/helm-container-build-push-3rd-gen.yml
@@ -1,0 +1,70 @@
+name: Container build and push 3rd gen
+
+on:
+  workflow_call:
+    inputs:
+      build-context:
+        description: "Path to image build context. Default: ."
+        default: .
+      build-docker-file:
+        description: "Path to the docker file. Default: ./Dockerfile"
+        default: ./Dockerfile
+      build-args:
+        description: "Use these build-args for the docker build process. It is not possible to use secrets in here! Use the action."
+        type: string
+        default: ""
+      helm-chart:
+        description: "The name of the helm chart to update. If not set, no chart update will be done. Default: empty"
+        default: ""
+      image-labels:
+        description: "Image labels."
+        required: true
+      image-url:
+        description: "Image url/name without registry."
+        required: true
+      image-platforms:
+        description: "Image platforms to build for. Default: linux/amd64"
+        default: linux/amd64
+    secrets:
+      COSIGN_KEY_OPENSIGHT:
+        required: true
+      COSIGN_KEY_PASSWORD_OPENSIGHT:
+        required: true
+      GREENBONE_BOT:
+        required: true
+      GREENBONE_BOT_PACKAGES_WRITE_TOKEN:
+        required: true
+      GREENBONE_BOT_TOKEN:
+        required: true
+
+jobs:
+  building-container:
+    runs-on: "ubuntu-latest"
+    outputs:
+      digest: ${{ steps.build-and-push.outputs.digest }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Container build and push 3rd gen
+        id: build-and-push
+        uses: greenbone/actions/container-build-push-3rd-gen@v3
+        with:
+          build-context: ${{ inputs.build-context }}
+          build-docker-file: ${{ inputs.build-docker-file }}
+          build-args: ${{ inputs.build-args }}
+          cosign-key: ${{ secrets.COSIGN_KEY_OPENSIGHT }}
+          cosign-key-password: ${{ secrets.COSIGN_KEY_PASSWORD_OPENSIGHT }}
+          image-url: ${{ inputs.image-url }}
+          image-labels: ${{ inputs.image-labels }}
+          image-platforms: ${{ inputs.image-platforms }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  building-helm-chart:
+    if: (inputs.helm-chart) && (startsWith(github.ref, 'refs/tags/v'))
+    needs:
+      - building-container
+    uses: greenbone/workflows/.github/workflows/helm-build-push-3rd-gen.yml@main
+    with:
+      chart: ${{ inputs.helm-chart }}
+      container-digest: ${{ needs.build-and-push.outputs.digest }}
+    secrets: inherit

--- a/.github/workflows/helm-container-build-push-3rd-gen.yml
+++ b/.github/workflows/helm-container-build-push-3rd-gen.yml
@@ -11,7 +11,6 @@ on:
         default: ./Dockerfile
       build-args:
         description: "Use these build-args for the docker build process. It is not possible to use secrets in here! Use the action."
-        type: string
         default: ""
       helm-chart:
         description: "The name of the helm chart to update. If not set, no chart update will be done. Default: empty"

--- a/README.md
+++ b/README.md
@@ -416,6 +416,42 @@ Inputs:
 |------|-------------|-|
 | chart | Helm Chart to update | Required |
 
+### Helm Build/Push 3rd gen
+
+Helm build push workflow that add's the container digest after the container tag.
+
+```yaml
+name: Helm chart release on tag
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  release-helm-chart:
+    name: Release helm chart
+    uses: greenbone/workflows/.github/workflows/helm-build-push.yml@main
+    with:
+      chart: myChart
+      container-digest: containerDigest
+    secrets: inherit
+```
+
+Secrets:
+
+| Name | Description | |
+|------|-------------|-|
+| GREENBONE_BOT | Username of the Greenbone Bot Account | Required |
+| GREENBONE_BOT_PACKAGES_WRITE_TOKEN | Token to upload packages to ghcr.io | Required |
+| GREENBONE_BOT_TOKEN | Token to trigger product helm chart updates | Required |
+
+Inputs:
+
+| Name | Description | |
+|------|-------------|-|
+| chart | Helm Chart to update | Required |
+| container-digest | The container digest for the helm chart tag. | Required |
+
 ### Deploy docs on GitHub Pages
 
 A workflow to generate a Python documentation and deploy it on GitHub Pages.

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ on:
 jobs:
   release-helm-chart:
     name: Release helm chart
-    uses: greenbone/workflows/.github/workflows/helm-build-push.yml@main
+    uses: greenbone/workflows/.github/workflows/helm-build-push-3rd-gen.yml@main
     with:
       chart: myChart
       container-digest: containerDigest
@@ -600,7 +600,7 @@ permissions:
 jobs:
   building:
     name: Build Container Image
-    uses: greenbone/workflows/.github/workflows/container-build-push-3rd-gen.yml@main
+    uses: greenbone/workflows/.github/workflows/helm-container-build-push-3rd-gen.yml@main
     with:
       image-url: ${{ vars.IMAGE_REGISTRY }}/${{ github.repository }}
       helm-chart: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -544,6 +544,48 @@ Inputs:
 | build-docker-file | Path to the docker file. Default "./Dockerfile" | Optional |
 | build-args | Use these build-args for the docker build process. | Optional |
 
+### Build and push 3rd gen container images and related helm chart
+
+A workflow to build and push 3rd gen container images and the related helm chart.
+In order to have a reasonable container digest transfer to the helm chart release 
+we have to build the container and helm charts in the same workflow.
+
+```yml
+name: Build Container Image Builds
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  building:
+    name: Build Container Image
+    uses: greenbone/workflows/.github/workflows/container-build-push-3rd-gen.yml@main
+    with:
+      image-url: ${{ vars.IMAGE_REGISTRY }}/${{ github.repository }}
+      helm-chart: ${{ github.repository }}
+      image-labels: |
+        org.opencontainers.image.vendor=Greenbone
+        org.opencontainers.image.base.name=alpine/latest
+    secrets: inherit
+```
+
+Inputs:
+
+| Name | Description | |
+|------|-------------|-|
+| build-context | Path to image build context. Default "." | Optional |
+| build-docker-file | Path to the docker file. Default "./Dockerfile" | Optional |
+| build-args | Use these build-args for the docker build process. | Optional |
+| helm-chart | The name of the helm chart to update. If not set, no chart update will be done. Default: empty | Optional |
+| image-labels | Image labels. | Required |
+| image-url | Image url/name without registry. | Required |
+| image-platforms | Image platforms to build for. Default "linux/amd64" | Optional |
+
 ## Support
 
 For any question on the usage of the workflows please use the


### PR DESCRIPTION
## What
Add: helm-container-build-push-3rd-gen and helm-build-push-3rd-gen
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
In order to have a reasonable container digest transfer to the helm chart release  we have to build the container and helm charts in the same workflow.
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-773
<!-- Add identifier for issue tickets, links to other PRs, etc. -->



