### PR TITLE
Add: status input value  to notify-mattermost-feed-deployment.yml

### DIFF
--- a/.github/workflows/notify-mattermost-feed-deployment.yml
+++ b/.github/workflows/notify-mattermost-feed-deployment.yml
@@ -43,7 +43,7 @@ jobs:
           workflow: ${{ github.run_id }}
           workflow-name: ${{ github.workflow }}
           status: ${{ inputs.status }}
-      - name: Exit with job status
+      - name: Exit with monitored job status
         if: inputs.exit-with-status == 'true' && inputs.status != 'success'
         run: |
           echo "Monitored job failed. Exit job/workflow with failure"

--- a/.github/workflows/notify-mattermost-feed-deployment.yml
+++ b/.github/workflows/notify-mattermost-feed-deployment.yml
@@ -7,6 +7,10 @@ on:
         description: "The commit used by the github checkout action. Default: main branch"
         type: string
         default: "main"
+      exit-with-status:
+        description: "Exit this job/workflow with the monitored job status. Options: true or false. Default: true"
+        type: string
+        default: "true"
       highlight:
         description: "Mattermost highlight. Default: devops"
         type: string
@@ -39,3 +43,8 @@ jobs:
           workflow: ${{ github.run_id }}
           workflow-name: ${{ github.workflow }}
           status: ${{ inputs.status }}
+      - name: Exit with job status
+        if: inputs.exit-with-status == 'true' && inputs.status != 'success'
+        run: |
+          echo "Monitored job failed. Exit job/workflow with failure"
+          exit 1

--- a/.github/workflows/notify-mattermost-feed-deployment.yml
+++ b/.github/workflows/notify-mattermost-feed-deployment.yml
@@ -4,13 +4,17 @@ on:
   workflow_call:
     inputs:
       commit:
-        description: "The commit used by the github checkout action."
+        description: "The commit used by the github checkout action. Default: main branch"
         type: string
-        required: true
+        default: "main"
       highlight:
         description: "Mattermost highlight. Default: devops"
         type: string
         default: "devops"
+      status:
+        description: "The monitored job, job status."
+        type: string
+        required: true
     secrets:
       MATTERMOST_FEED_BOT_WEBHOOK_URL:
         required: true
@@ -22,6 +26,7 @@ jobs:
     runs-on:
       - self-hosted
       - self-hosted-generic
+    if: ${{ !cancelled() }} && ( inputs.status == 'failure' || inputs.status == 'success' )
     steps:
       - name: Notify Mattermost Feed Deployment
         uses: greenbone/actions/mattermost-notify@v3
@@ -33,3 +38,4 @@ jobs:
           commit: ${{ inputs.commit }}
           workflow: ${{ github.run_id }}
           workflow-name: ${{ github.workflow }}
+          status: ${{ inputs.status }}


### PR DESCRIPTION
## What
Add: status input value  to notify-mattermost-feed-deployment.yml
Add: exit-with-status input value
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
It looks like if a job runs after an other job. And the first job fails but the second job runs always  e.g with "if: always()". The workflow run at the end is not in a fail state. So we need to fail this notify job by input value from the first job,
<!-- DesDEVOPS-722cribe why are these changes necessary? -->

## References
DEVOPS-722



