### PR TITLE
Change: use github.sha as default for commit in mattermost notify

### DIFF
--- a/.github/workflows/notify-mattermost-feed-deployment.yml
+++ b/.github/workflows/notify-mattermost-feed-deployment.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       commit:
-        description: "The commit used by the github checkout action. Default: main branch"
+        description: "The commit used by the github checkout action. Default: github.sha"
         type: string
         default: ${{ github.sha }}
       exit-with-status:

--- a/.github/workflows/notify-mattermost-feed-deployment.yml
+++ b/.github/workflows/notify-mattermost-feed-deployment.yml
@@ -6,7 +6,7 @@ on:
       commit:
         description: "The commit used by the github checkout action. Default: main branch"
         type: string
-        default: "main"
+        default: ${{ github.sha }}
       exit-with-status:
         description: "Exit this job/workflow with the monitored job status. Options: true or false. Default: true"
         type: string


### PR DESCRIPTION
## What
Change: use github.sha as default for commit in mattermost notify
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
We should us the same default as in the action.
<!-- Describe why are these changes necessary? -->

## References
None



