### PR TITLE
Fix: Remove caching of poetry for Python based CI workflows

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -22,6 +22,5 @@ jobs:
         uses: greenbone/actions/poetry@v3
         with:
           python-version: ${{ inputs.python-version }}
-          cache-poetry-installation: "true"
       - name: Run unit tests
         run: poetry run ${{ inputs.test-command }}


### PR DESCRIPTION
## What

Remove caching of poetry for Python based CI workflows

## Why

Currently the caching seems to be broken since switching to pipx based installation of the applications. Therefore remove the caching of poetry for now.

## References
https://github.com/greenbone/autohooks-plugin-pylint/actions/runs/5710696688/job/15514172248?pr=407
