### PR TITLE
Change: Fix wording for python linting workflow

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
-      - name: Install and check with black, pylint and pontos.version
+      - name: Check and lint python packages
         uses: greenbone/actions/lint-python@v3
         with:
           packages: ${{ inputs.lint-packages }}


### PR DESCRIPTION


## What

Fix wording for python linting workflow

## Why
It's possible to use a project specific linter and pylint isn't used always.

