### PR TITLE
Extend release workflows

### DIFF
--- a/.github/workflows/release-cloud.yml
+++ b/.github/workflows/release-cloud.yml
@@ -4,11 +4,10 @@ on:
   workflow_call:
     inputs:
       git-tag-prefix:
-        description: "Set git tag prefix to the passed input. Default: ''"
-        default: ""
+        description: "Ignored. Always `''`"
         type: string
       release-type:
-        description: "Release type. One of alpha, patch, minor, major, release-candidate"
+        description: "Ignored. Always calendar."
         type: string
       release-version:
         description: "Set an explicit version, that will overwrite release-type. Fails if version is not compliant."
@@ -32,10 +31,12 @@ jobs:
     name: Create a new release
     uses: ./.github/workflows/release-generic.yml
     with:
-      git-tag-prefix: ${{ inputs.git-tag-prefix }}
-      release-type: ${{ inputs.release-type }}
+      git-tag-prefix: ""
+      release-type: "calendar"
       release-version: ${{ inputs.release-version }}
       versioning-scheme: "pep440"
+      github-pre-release: "true"
+      next-version: "false"
     secrets:
       GREENBONE_BOT: ${{ secrets.GREENBONE_BOT }}
       GREENBONE_BOT_MAIL: ${{ secrets.GREENBONE_BOT_MAIL }}

--- a/.github/workflows/release-generic.yml
+++ b/.github/workflows/release-generic.yml
@@ -21,6 +21,12 @@ on:
         description: "Update version in project files like `pyproject.toml`. Default is 'true'."
         default: "true"
         type: string
+      next-version:
+        description: "Set an explicit version that should be used after the release. Leave empty for determining the next version automatically. Set to 'false' for not updating the version after a release."
+        type: string
+      github-pre-release:
+        description: "Set to `'true'` to enforce uploading the release to GitHub as a pre-release"
+        type: string
     secrets:
       GREENBONE_BOT:
         required: true
@@ -103,3 +109,5 @@ jobs:
           ref: ${{ steps.ref.outputs.release_ref }}
           versioning-scheme: ${{ inputs.versioning-scheme }}
           update-project: ${{ inputs.update-project }}
+          next-version: ${{ inputs.next-version }}
+          github-pre-release: ${{ inputs.github-pre-release }}


### PR DESCRIPTION
## What
Extend workflow for cloud release process

## Why

Cloud will always create calendar based releases and tags without a
leading 'v'. Additionally the cloud workflow should not update the
version after a release to not create an additional commit.
All releases for the cloud will be marked as pre-releases initially and
are changed to "real" releases manually after testing the release.

## References

DEVOPS-826
DEVOPS-828
