### PR TITLE
Remove:  input validation from mattermost notify 

### DIFF
--- a/.github/workflows/notify-mattermost-3rd-gen-ci.yml
+++ b/.github/workflows/notify-mattermost-3rd-gen-ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on:
       - self-hosted
       - self-hosted-generic
-    if: ${{ !cancelled() && (inputs.status == 'failure' || inputs.status == 'success') }}
+    if: ${{ !cancelled() }}
     steps:
       - name: Notify Mattermost 3rd gen ci
         uses: greenbone/actions/mattermost-notify@v3

--- a/.github/workflows/notify-mattermost-3rd-gen.yml
+++ b/.github/workflows/notify-mattermost-3rd-gen.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on:
       - self-hosted
       - self-hosted-generic
-    if: ${{ !cancelled() && (inputs.status == 'failure' || inputs.status == 'success') }}
+    if: ${{ !cancelled() }}
     steps:
       - name: Notify Mattermost 3rd gen
         uses: greenbone/actions/mattermost-notify@v3

--- a/.github/workflows/notify-mattermost-feed-deployment.yml
+++ b/.github/workflows/notify-mattermost-feed-deployment.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on:
       - self-hosted
       - self-hosted-generic
-    if: ${{ !cancelled() && (inputs.status == 'failure' || inputs.status == 'success') }}
+    if: ${{ !cancelled() }}
     steps:
       - name: Notify Mattermost Feed Deployment
         uses: greenbone/actions/mattermost-notify@v3

--- a/.github/workflows/notify-mattermost-qm.yml
+++ b/.github/workflows/notify-mattermost-qm.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on:
       - self-hosted
       - self-hosted-generic
-    if: ${{ !cancelled() && (inputs.status == 'failure' || inputs.status == 'success') }}
+    if: ${{ !cancelled() }}
     steps:
       - name: Notify Mattermost QM
         uses: greenbone/actions/mattermost-notify@v3


### PR DESCRIPTION
## What
Remove:  input validation from notify-mattermost-feed-deployment.yml

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Github display of skipped jobs are horrible!! So remove this or nobody can see what's going on at first glance.

<!-- Describe why are these changes necessary? -->

## References
None



