### PR TITLE
Change: Move trigger steps into own job

### DIFF
--- a/.github/workflows/helm-container-build-push-3rd-gen.yml
+++ b/.github/workflows/helm-container-build-push-3rd-gen.yml
@@ -110,6 +110,11 @@ jobs:
           scout-user: ${{ contains(inputs.scout, 'true') && secrets.DOCKERHUB_USERNAME || '' }}
           scout-password: ${{ contains(inputs.scout, 'true') && secrets.DOCKERHUB_TOKEN || '' }}
 
+  building-chart:
+    needs:
+      - building-container
+    runs-on: "ubuntu-latest"
+    steps:
       - name: Trigger service helm chart upgrade
         if: (inputs.helm-chart) && (startsWith(github.ref, 'refs/tags/v'))
         uses: greenbone/actions/trigger-workflow@v3
@@ -117,7 +122,7 @@ jobs:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: "greenbone/product-helm-chart"
           workflow: "service-chart-upgrade.yml"
-          inputs: '{"chart": "${{ inputs.helm-chart }}", "chart-version": "${{ github.ref_name }}", "container-digest": "${{ steps.build-and-push.outputs.digest }}", "init-container": "${{ inputs.init-container }}", "init-container-digest": "${{ inputs.init-container-digest }}"}'
+          inputs: '{"chart": "${{ inputs.helm-chart }}", "chart-version": "${{ github.ref_name }}", "container-digest": "${{ needs.building-container.outputs.digest }}", "init-container": "${{ inputs.init-container }}", "init-container-digest": "${{ inputs.init-container-digest }}"}'
 
       - name: Trigger product helm chart upgrade
         if: (inputs.helm-chart) && (startsWith(github.ref, 'refs/tags/v'))
@@ -131,6 +136,7 @@ jobs:
 notify:
     needs:
       - building-container
+      - building-chart
     if: ${{ !cancelled() && startsWith(github.ref, 'refs/tags/v')  && startsWith(inputs.notify, 'true') }}
     uses: greenbone/workflows/.github/workflows/notify-mattermost-3rd-gen.yml@main
     with:


### PR DESCRIPTION
## What
Change: Move trigger steps into own job in helm-container-build-push-3rd-gen.yml

## Why
DEVOPS-863
Much better to restart if the trigger steps fail.
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-863



