### PR TITLE
Change: split trigger service chart and trigger product chart into two

### DIFF
--- a/.github/workflows/helm-container-build-push-3rd-gen.yml
+++ b/.github/workflows/helm-container-build-push-3rd-gen.yml
@@ -110,13 +110,13 @@ jobs:
           scout-user: ${{ contains(inputs.scout, 'true') && secrets.DOCKERHUB_USERNAME || '' }}
           scout-password: ${{ contains(inputs.scout, 'true') && secrets.DOCKERHUB_TOKEN || '' }}
 
-  building-chart:
+  building-service-chart:
+    if: (inputs.helm-chart) && (startsWith(github.ref, 'refs/tags/v'))
     needs:
       - building-container
     runs-on: "ubuntu-latest"
     steps:
       - name: Trigger service helm chart upgrade
-        if: (inputs.helm-chart) && (startsWith(github.ref, 'refs/tags/v'))
         uses: greenbone/actions/trigger-workflow@v3
         with:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
@@ -124,8 +124,14 @@ jobs:
           workflow: "service-chart-upgrade.yml"
           inputs: '{"chart": "${{ inputs.helm-chart }}", "chart-version": "${{ github.ref_name }}", "container-digest": "${{ needs.building-container.outputs.digest }}", "init-container": "${{ inputs.init-container }}", "init-container-digest": "${{ inputs.init-container-digest }}"}'
 
+  building-product-chart:
+    if: (inputs.helm-chart) && (startsWith(github.ref, 'refs/tags/v'))
+    needs:
+      - building-container
+      - building-service-chart
+    runs-on: "ubuntu-latest"
+    steps:
       - name: Trigger product helm chart upgrade
-        if: (inputs.helm-chart) && (startsWith(github.ref, 'refs/tags/v'))
         uses: greenbone/actions/trigger-workflow@v3
         with:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
@@ -136,7 +142,8 @@ jobs:
   notify:
     needs:
       - building-container
-      - building-chart
+      - building-service-chart
+      - building-product-chart
     if: ${{ !cancelled() && startsWith(github.ref, 'refs/tags/v')  && startsWith(inputs.notify, 'true') }}
     uses: greenbone/workflows/.github/workflows/notify-mattermost-3rd-gen.yml@main
     with:


### PR DESCRIPTION
jobs
Change: split trigger service chart and trigger product chart into two
## What

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Through the division into two jobs, it is easy to restart only one job in case of an error, rather than allowing both to restart simultaneously.
<!-- Describe why are these changes necessary? -->

## References
None


