### PR TITLE
PyPI trusted publisher

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -4,10 +4,18 @@ on:
   workflow_call:
     secrets:
       PYPI_TOKEN:
+    inputs:
+      pypi-url:
+        description: 'URL to the project on PyPI.org'
+        required: false
+        type: string
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: ${{ inputs.pypi-url }}
     steps:
       - name: Build and publish to PyPI
         uses: greenbone/actions/pypi-upload@v3

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -4,7 +4,6 @@ on:
   workflow_call:
     secrets:
       PYPI_TOKEN:
-        required: true
 
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -186,7 +186,10 @@ Inputs:
 
 ### Deploy on PyPI
 
-A workflow to deploy a Python package on [PyPI](https://www.pypi.org).
+A workflow to deploy a Python package on [PyPI](https://www.pypi.org). It
+requires a `pypi` [GitHub Environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment).
+
+Example using `secrets.PYPI_TOKEN`:
 
 ```yml
 name: Deploy on PyPI
@@ -201,11 +204,28 @@ jobs:
     secrets: inherit
 ```
 
+Example using [trusted publisher](https://docs.pypi.org/trusted-publishers/):
+
+```yml
+name: Deploy on PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+    uses: greenbone/workflows/.github/workflows/deploy-pypi.yml@main
+```
+
 Secrets:
 
 | Name       | Description                                          |          |
 | ---------- | ---------------------------------------------------- | -------- |
 | PYPI_TOKEN | Token with permissions to upload the package to PyPI | Optional |
+| pypi-url   | URL to the project on PyPI.org                       | Optional |
 
 ### Codecov Python
 

--- a/README.md
+++ b/README.md
@@ -203,9 +203,9 @@ jobs:
 
 Secrets:
 
-| Name | Description | |
-|------|-------------|-|
-| PYPI_TOKEN | Token with permissions to upload the package to PyPI | Required |
+| Name       | Description                                          |          |
+| ---------- | ---------------------------------------------------- | -------- |
+| PYPI_TOKEN | Token with permissions to upload the package to PyPI | Optional |
 
 ### Codecov Python
 


### PR DESCRIPTION
## What

Extend reusable `deploy-pypi.yml` workflow for supporting trusted publisher uploads.

## Why

Trusted publisher uploads increase security for deployments.

## References

DEVOPS-931