### PR TITLE
Add: Allow to use "calendar release" label for relase type calendar

### DIFF
--- a/.github/workflows/release-generic.yml
+++ b/.github/workflows/release-generic.yml
@@ -56,6 +56,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'rc release') ||
           contains(github.event.pull_request.labels.*.name, 'patch release') ||
           contains(github.event.pull_request.labels.*.name, 'make release') ||
+          contains(github.event.pull_request.labels.*.name, 'calendar release') ||
           contains(github.event.pull_request.labels.*.name, 'minor release') ||
           contains(github.event.pull_request.labels.*.name, 'major release')) &&
           github.event.pull_request.merged == true )

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -44,6 +44,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'rc release') ||
           contains(github.event.pull_request.labels.*.name, 'patch release') ||
           contains(github.event.pull_request.labels.*.name, 'make release') ||
+          contains(github.event.pull_request.labels.*.name, 'calendar release') ||
           contains(github.event.pull_request.labels.*.name, 'minor release') ||
           contains(github.event.pull_request.labels.*.name, 'major release')) &&
           github.event.pull_request.merged == true )


### PR DESCRIPTION


## What

Allow to use "calendar release" label for relase type calendar

## Why
Re-add "calendar release" label for creating calver releases. This label is used by the cloud team.


