### PR TITLE
Add: Create multi arch manifest in container-build-push-2nd-gen.yml

### DIFF
--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -47,22 +47,16 @@ on:
         required: false
 
 # INFO
-# We need to run the multi-platform builds in a matrix
-# because the Docker build process does not return
-# the image digest for multi-platform builds.
-# We need this digest for cosign.
+# We cannot use a matrix here because job outputs from matrix jobs cannot be passed to other jobs.
+# Due to cosign and the use of native runners, we cannot use the platform build mode from buildx anymore.
+# This means we have to build our own multi-arch manifest.
 
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: self-hosted-generic
-          - platform: linux/arm64
-            runner: self-hosted-generic-arm64
-    runs-on: ${{ matrix.runner }}
+  build-amd64:
+    runs-on: self-hosted-generic
+    outputs:
+      digest: ${{ steps.build-and-push.outputs.digest }}
+      tags: ${{ steps.build-and-push.outputs.tags }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -110,6 +104,7 @@ jobs:
             type=ref,event=pr
             type=raw,value=latest,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
             type=raw,value=stable,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
+            type=raw,value=edge,enable=${{ inputs.ref-name == 'main' }}
           image-platforms: ${{ matrix.platform }}
           registry: ${{ secrets.GREENBONE_REGISTRY }}
           registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}
@@ -118,9 +113,93 @@ jobs:
           scout-password: ${{ secrets.DOCKERHUB_TOKEN }}
           scout-command: cves
 
+  build-arm64:
+    runs-on: self-hosted-generic-arm64
+    outputs:
+      digest: ${{ steps.build-and-push.outputs.digest }}
+      tags: ${{ steps.build-and-push.outputs.tags }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ inputs.ref-name }}
+
+      - uses: greenbone/actions/is-latest-tag@v3
+        id: latest
+        with:
+          tag-name: ${{ inputs.ref-name }}
+
+      - name: Set container build options
+        id: container-opts
+        run: |
+          if [[ "${{ github.ref_type }}" = 'tag' ]]; then
+            echo "version=stable" >> $GITHUB_OUTPUT
+            echo "gvm-libs-version=oldstable" >> $GITHUB_OUTPUT
+          else
+            echo "version=edge" >> $GITHUB_OUTPUT
+            echo "gvm-libs-version=oldstable-edge" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Container build and push 3rd gen
+        id: build-and-push
+        uses: greenbone/actions/container-build-push-generic@v3
+        with:
+          build-context: ${{ inputs.build-context }}
+          build-docker-file: ${{ inputs.build-docker-file }}
+          build-args: |
+            VERSION=${{ steps.container-opts.outputs.version }}
+            GVM_LIBS_VERSION=${{ steps.container-opts.outputs.gvm-libs-version }}
+            IMAGE_REGISTRY=${{ vars.IMAGE_REGISTRY }}
+          cosign-key: ${{ secrets.COSIGN_KEY_OPENSIGHT }}
+          cosign-key-password: ${{ secrets.COSIGN_KEY_PASSWORD_OPENSIGHT }}
+          cosign-tlog-upload: "false"
+          image-url: ${{ inputs.image-url }}
+          image-labels: ${{ inputs.image-labels }}
+          image-tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=edge
+            type=ref,event=pr
+            type=raw,value=latest,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
+            type=raw,value=stable,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
+            type=raw,value=edge,enable=${{ inputs.ref-name == 'main' }}
+          image-platforms: ${{ matrix.platform }}
+          registry: ${{ secrets.GREENBONE_REGISTRY }}
+          registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}
+          registry-password: ${{ secrets.GREENBONE_REGISTRY_TOKEN }}
+          scout-user: ${{ secrets.DOCKERHUB_USERNAME }}
+          scout-password: ${{ secrets.DOCKERHUB_TOKEN }}
+          scout-command: cves
+
+  create-multi-arch-manifest:
+    if: github.event_name != 'pull_request'
+    runs-on: self-hosted-generic
+    needs:
+      - build-amd64
+      - build-arm64
+    steps:
+      - name: Create multi arch manifest
+        uses: greenbone/actions/container-multi-arch-manifest@v3
+        with:
+          tags: |
+            ${{ needs.build-amd64.outputs.tags }}
+            ${{ needs.build-arm64.outputs.tags }}
+          digests: |
+            ${{ needs.build-amd64.outputs.digest }}
+            ${{ needs.build-arm64.outputs.digest }}
+          url: ${{ inputs.image-url }}
+          registry: ${{ secrets.GREENBONE_REGISTRY }}
+          registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}
+          registry-password: ${{ secrets.GREENBONE_REGISTRY_TOKEN }}
+
   notify:
     needs:
-      - build
+      - build-amd64
+      - build-arm64
+      - create-manifest
     if: ${{ !cancelled() && startsWith(github.ref, 'refs/tags/v')  && startsWith(inputs.notify, 'true') }}
     uses: greenbone/workflows/.github/workflows/notify-mattermost-3rd-gen.yml@main
     with:

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -199,7 +199,7 @@ jobs:
     needs:
       - build-amd64
       - build-arm64
-      - create-manifest
+      - create-multi-arch-manifest
     if: ${{ !cancelled() && startsWith(github.ref, 'refs/tags/v')  && startsWith(inputs.notify, 'true') }}
     uses: greenbone/workflows/.github/workflows/notify-mattermost-3rd-gen.yml@main
     with:


### PR DESCRIPTION
## What
 Add: Create multi arch manifest in container-build-push-2nd-gen.yml
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
We cannot use a matrix here because job outputs from matrix jobs cannot be passed to other jobs.
Due to cosign and the use of native runners, we cannot use the platform build mode from buildx anymore.
This means we have to build our own multi-arch manifest.
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-1082
<!-- Add identifier for issue tickets, links to other PRs, etc. -->


