### PR TITLE
Change: Don't build arm images on PR's in container-build-push-2nd-gen.yml

### DIFF
--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -126,6 +126,8 @@ jobs:
           scout-command: cves
 
   build-arm64:
+    # At the moment we don't have enough arm runners to provide a run for every PR!
+    if: github.event_name != 'pull_request'
     runs-on: self-hosted-generic-arm64
     outputs:
       digest: ${{ steps.build-and-push.outputs.digest }}


### PR DESCRIPTION
## What
Change: Don't build arm images on PR's in container-build-push-2nd-gen.yml
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
At the moment we don't have enough arm runners to provide a run for every PR!
<!-- Describe why are these changes necessary? -->

## References
None



