### PR TITLE
Change: Set github.ref_name as default for ref-name in container-build-push-2nd-gen.yml

### DIFF
--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       ref-name:
         description: "The ref to build a container image from. For example a tag v23.0.0."
-        required: false
+        default: ${{ github.ref_name }}
         type: string
       build-context:
         description: "Path to image build context. Default is ."


### PR DESCRIPTION
## What
Change: Set github.ref_name as default for ref-name in container-build-push-2nd-gen.yml

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
We need always a ref name for is latest tag check.
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-1135



