### PR TITLE
Change: always set a tag-name on is-latest-tag action

### DIFF
--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -86,7 +86,8 @@ jobs:
       - uses: greenbone/actions/is-latest-tag@v3
         id: latest
         with:
-          tag-name: ${{ inputs.ref-name }}
+          # It looks like the action doesn't use its default value even when an empty input is set.
+          tag-name: ${{ inputs.ref-name || github.ref_name }}
 
       - name: Set container build options
         id: container-opts
@@ -112,9 +113,12 @@ jobs:
           image-url: ${{ inputs.image-url }}
           image-labels: ${{ inputs.image-labels }}
           image-tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},value=${{ inputs.ref-name }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.ref-name }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=semver,pattern={{major}},value=${{ inputs.ref-name }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=semver,pattern={{major}},enable=${{ github.event_name != 'workflow_dispatch' }}
             type=edge
             type=ref,event=pr
             type=raw,value=latest,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
@@ -154,7 +158,8 @@ jobs:
       - uses: greenbone/actions/is-latest-tag@v3
         id: latest
         with:
-          tag-name: ${{ inputs.ref-name }}
+          # It looks like the action doesn't use its default value even when an empty input is set.
+          tag-name: ${{ inputs.ref-name || github.ref_name }}
 
       - name: Set container build options
         id: container-opts


### PR DESCRIPTION
## What
Change: always set a tag-name on is-latest-tag action
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
It looks like the action doesn't use its default value even when an empty input is set.
<!-- Describe why are these changes necessary? -->

## References
None



