### PR TITLE
Change: Add base-image-label as input, control image-tags by base-image-label.

### DIFF
--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -18,7 +18,7 @@ on:
         description: "Image labels."
         required: true
         type: string
-      image-type:
+      base-image-label:
         description: "Base image tag (Debian)."
         required: true
         default: "stable"

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -120,7 +120,7 @@ jobs:
             IMAGE_REGISTRY=${{ vars.IMAGE_REGISTRY }}
           image-url: ${{ inputs.image-url }}
           image-labels: ${{ inputs.image-labels }}
-          image-tags: type=raw,value=${{ inputs.ref_name }} # temporary tag that will be overwritten with the manifest upload
+          image-tags: raw,value=${{ inputs.ref-name || github.ref_name }}-amd64 # temporary tag that will be overwritten with the manifest upload
           image-platforms: linux/amd64
           registry: ${{ secrets.GREENBONE_REGISTRY }}
           registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}
@@ -181,7 +181,7 @@ jobs:
             IMAGE_REGISTRY=${{ vars.IMAGE_REGISTRY }}
           image-url: ${{ inputs.image-url }}
           image-labels: ${{ inputs.image-labels }}
-          image-tags: type=raw,value=${{ inputs.ref_name }} # temporary tag that will be overwritten with the manifest upload
+          image-tags: raw,value=${{ inputs.ref-name || github.ref_name }}-arm64 # temporary tag that will be overwritten with the manifest upload
           image-platforms: linux/arm64
           registry: ${{ secrets.GREENBONE_REGISTRY }}
           registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -118,6 +118,7 @@ jobs:
           image-labels: ${{ inputs.image-labels }}
           image-tags: raw,value=${{ inputs.ref-name || github.ref_name }}-amd64 # temporary tag that will be overwritten with the manifest upload
           image-platforms: linux/amd64
+          image-flavor: latest=false
           registry: ${{ secrets.GREENBONE_REGISTRY }}
           registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}
           registry-password: ${{ secrets.GREENBONE_REGISTRY_TOKEN }}
@@ -179,6 +180,7 @@ jobs:
           image-labels: ${{ inputs.image-labels }}
           image-tags: raw,value=${{ inputs.ref-name || github.ref_name }}-arm64 # temporary tag that will be overwritten with the manifest upload
           image-platforms: linux/arm64
+          image-flavor: latest=false
           registry: ${{ secrets.GREENBONE_REGISTRY }}
           registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}
           registry-password: ${{ secrets.GREENBONE_REGISTRY_TOKEN }}

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -19,12 +19,10 @@ on:
         required: true
         type: string
       base-image-label:
-        description: "Base image tag (Debian)."
+        description: "Base image tag (Debian). Possible options: stable, oldstable, testing"
         required: true
-        options:
-          - stable
-          - oldstable
-          - testing
+        default: "stable"
+        type: string
       image-url:
         description: "Image url/name without registry."
         required: true

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -218,7 +218,7 @@ jobs:
             type=raw,value=testing-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'testing') }}
 
       - name: Create multi arch manifest
-        uses: greenbone/actions/container-multi-arch-manifest@pholthaus/meta_tags_manifest
+        uses: greenbone/actions/container-multi-arch-manifest@v3
         with:
           cosign-key: ${{ secrets.COSIGN_KEY_OPENSIGHT }}
           cosign-key-password: ${{ secrets.COSIGN_KEY_PASSWORD_OPENSIGHT }}

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -260,7 +260,7 @@ jobs:
       - create-multi-arch-manifest
       - test-pull-amd64
       - test-pull-arm64
-    if: ${{ !cancelled()  && startsWith(inputs.notify, 'true') }}
+    if: ${{ !cancelled()  && startsWith(inputs.notify, 'true') && github.event_name != 'pull_request' }}
     uses: greenbone/workflows/.github/workflows/notify-mattermost-3rd-gen.yml@main
     with:
       status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -239,7 +239,7 @@ jobs:
           registry-password: ${{ secrets.GREENBONE_REGISTRY_TOKEN }}
 
   test-pull-arm64:
-    if: ${{ (jobs.build-arm64.outputs.is-latest-tag == 'true') && (inputs. inputs.base-image-label == 'stable') && (github.event_name != 'pull_request') }}
+    if: ${{ (needs.build-arm64.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'stable') && (github.event_name != 'pull_request') }}
     name: Test pulling the image on arm64
     needs: [build-arm64, create-multi-arch-manifest]
     runs-on: self-hosted-generic-arm64
@@ -248,7 +248,7 @@ jobs:
         run: docker pull registry.community.greenbone.net/${{ inputs.image-url }}:latest
 
   test-pull-amd64:
-    if: ${{ (jobs.build-amd64.outputs.is-latest-tag == 'true') && (inputs. inputs.base-image-label == 'stable') && (github.event_name != 'pull_request') }}
+    if: ${{ (needs.build-amd64.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'stable') && (github.event_name != 'pull_request') }}
     name: Test pulling the image on amd64
     needs: [build-amd64, create-multi-arch-manifest]
     runs-on: self-hosted-generic

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -20,7 +20,6 @@ on:
         type: string
       base-image-label:
         description: "Base image tag (Debian). Possible options: stable, oldstable, testing"
-        required: true
         default: "stable"
         type: string
       image-url:

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -200,6 +200,7 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: ${{ secrets.GREENBONE_REGISTRY }}/${{ inputs.image-url }}
+          flavor: latest=false
           tags: |
             type=semver,pattern={{version}},value=${{ inputs.ref-name }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=semver,pattern={{version}},enable=${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -197,7 +197,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
-          images: ${{ inputs.image-url }}
+          images: ${{ secrets.GREENBONE_REGISTRY }}/${{ inputs.image-url }}
           tags: |
             type=semver,pattern={{version}},value=${{ inputs.ref-name }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=semver,pattern={{version}},enable=${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -234,6 +234,7 @@ jobs:
           registry-password: ${{ secrets.GREENBONE_REGISTRY_TOKEN }}
 
   test-pull-arm64:
+    if: inputs.base-image-label == 'stable'
     name: Test pulling the image on arm64
     needs: [build-arm64, create-multi-arch-manifest]
     runs-on: self-hosted-generic-arm64
@@ -242,6 +243,7 @@ jobs:
         run: docker pull registry.community.greenbone.net/${{ inputs.image-url }}:latest
 
   test-pull-amd64:
+    if: inputs.base-image-label == 'stable'
     name: Test pulling the image on amd64
     needs: [build-amd64, create-multi-arch-manifest]
     runs-on: self-hosted-generic

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -21,7 +21,6 @@ on:
       base-image-label:
         description: "Base image tag (Debian)."
         required: true
-        default: "stable"
         options:
           - stable
           - oldstable

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -18,6 +18,14 @@ on:
         description: "Image labels."
         required: true
         type: string
+      image-type:
+        description: "Image type."
+        required: true
+        default: "stable"
+        options:
+          - stable
+          - oldstable
+          - testing
       image-url:
         description: "Image url/name without registry."
         required: true
@@ -121,9 +129,13 @@ jobs:
             type=semver,pattern={{major}},enable=${{ github.event_name != 'workflow_dispatch' }}
             type=edge
             type=ref,event=pr
-            type=raw,value=latest,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
-            type=raw,value=stable,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
-            type=raw,value=edge,enable=${{ (inputs.ref-name || github.ref_name) == 'main' }}
+            type=raw,value=latest,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'stable') }}
+            type=raw,value=stable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'stable') }}
+            type=raw,value=edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.image-type == 'stable') }}
+            type=raw,value=oldstable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'oldstable') }}
+            type=raw,value=oldstable-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.image-type == 'oldstable') }}
+            type=raw,value=testing,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'testing') }}
+            type=raw,value=testing-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.image-type == 'testing') }}
           image-platforms: linux/amd64
           registry: ${{ secrets.GREENBONE_REGISTRY }}
           registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}
@@ -193,9 +205,13 @@ jobs:
             type=semver,pattern={{major}},enable=${{ github.event_name != 'workflow_dispatch' }}
             type=edge
             type=ref,event=pr
-            type=raw,value=latest,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
-            type=raw,value=stable,enable=${{ steps.latest.outputs.is-latest-tag == 'true' }}
-            type=raw,value=edge,enable=${{ (inputs.ref-name || github.ref_name) == 'main' }}
+            type=raw,value=latest,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'stable') }}
+            type=raw,value=stable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'stable') }}
+            type=raw,value=edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.image-type == 'stable') }}
+            type=raw,value=oldstable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'oldstable') }}
+            type=raw,value=oldstable-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.image-type == 'oldstable') }}
+            type=raw,value=testing,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'testing') }}
+            type=raw,value=testing-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.image-type == 'testing') }}
           image-platforms: linux/arm64
           registry: ${{ secrets.GREENBONE_REGISTRY }}
           registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -129,13 +129,13 @@ jobs:
             type=semver,pattern={{major}},enable=${{ github.event_name != 'workflow_dispatch' }}
             type=edge
             type=ref,event=pr
-            type=raw,value=latest,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'stable') }}
-            type=raw,value=stable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'stable') }}
-            type=raw,value=edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.image-type == 'stable') }}
-            type=raw,value=oldstable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'oldstable') }}
-            type=raw,value=oldstable-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.image-type == 'oldstable') }}
-            type=raw,value=testing,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'testing') }}
-            type=raw,value=testing-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.image-type == 'testing') }}
+            type=raw,value=latest,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'stable') }}
+            type=raw,value=stable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'stable') }}
+            type=raw,value=edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'stable') }}
+            type=raw,value=oldstable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'oldstable') }}
+            type=raw,value=oldstable-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'oldstable') }}
+            type=raw,value=testing,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'testing') }}
+            type=raw,value=testing-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'testing') }}
           image-platforms: linux/amd64
           registry: ${{ secrets.GREENBONE_REGISTRY }}
           registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}
@@ -205,13 +205,13 @@ jobs:
             type=semver,pattern={{major}},enable=${{ github.event_name != 'workflow_dispatch' }}
             type=edge
             type=ref,event=pr
-            type=raw,value=latest,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'stable') }}
-            type=raw,value=stable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'stable') }}
-            type=raw,value=edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.image-type == 'stable') }}
-            type=raw,value=oldstable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'oldstable') }}
-            type=raw,value=oldstable-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.image-type == 'oldstable') }}
-            type=raw,value=testing,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.image-type == 'testing') }}
-            type=raw,value=testing-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.image-type == 'testing') }}
+            type=raw,value=latest,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'stable') }}
+            type=raw,value=stable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'stable') }}
+            type=raw,value=edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'stable') }}
+            type=raw,value=oldstable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'oldstable') }}
+            type=raw,value=oldstable-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'oldstable') }}
+            type=raw,value=testing,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'testing') }}
+            type=raw,value=testing-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'testing') }}
           image-platforms: linux/arm64
           registry: ${{ secrets.GREENBONE_REGISTRY }}
           registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -216,7 +216,7 @@ jobs:
             type=raw,value=testing-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'testing') }}
 
       - name: Create multi arch manifest
-        uses: greenbone/actions/container-multi-arch-manifest@v3
+        uses: greenbone/actions/container-multi-arch-manifest@pholthaus/meta_tags_manifest
         with:
           cosign-key: ${{ secrets.COSIGN_KEY_OPENSIGHT }}
           cosign-key-password: ${{ secrets.COSIGN_KEY_PASSWORD_OPENSIGHT }}
@@ -224,7 +224,7 @@ jobs:
           annotations: |
             ${{ needs.build-amd64.outputs.annotations }}
             ${{ needs.build-arm64.outputs.annotations }}
-          tags: ${{ steps.meta.outputs.tags }}
+          meta-tags: ${{ steps.meta.outputs.tags }}
           digests: |
             ${{ needs.build-amd64.outputs.digest }}
             ${{ needs.build-arm64.outputs.digest }}

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -237,7 +237,7 @@ jobs:
           registry-password: ${{ secrets.GREENBONE_REGISTRY_TOKEN }}
 
   test-pull-arm64:
-    if: (steps.latest.outputs.is-latest-tag == 'true') && (inputs. inputs.base-image-label == 'stable') && (github.event_name != 'pull_request')
+    if: ${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs. inputs.base-image-label == 'stable') && (github.event_name != 'pull_request') }}
     name: Test pulling the image on arm64
     needs: [build-arm64, create-multi-arch-manifest]
     runs-on: self-hosted-generic-arm64
@@ -246,7 +246,7 @@ jobs:
         run: docker pull registry.community.greenbone.net/${{ inputs.image-url }}:latest
 
   test-pull-amd64:
-    if: (steps.latest.outputs.is-latest-tag == 'true') && (inputs. inputs.base-image-label == 'stable') && (github.event_name != 'pull_request')
+    if: ${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs. inputs.base-image-label == 'stable') && (github.event_name != 'pull_request') }}
     name: Test pulling the image on amd64
     needs: [build-amd64, create-multi-arch-manifest]
     runs-on: self-hosted-generic

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -19,7 +19,7 @@ on:
         required: true
         type: string
       image-type:
-        description: "Image type."
+        description: "Base image tag (Debian)."
         required: true
         default: "stable"
         options:

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -237,7 +237,7 @@ jobs:
           registry-password: ${{ secrets.GREENBONE_REGISTRY_TOKEN }}
 
   test-pull-arm64:
-    if: inputs.base-image-label == 'stable'
+    if: (steps.latest.outputs.is-latest-tag == 'true') && (inputs. inputs.base-image-label == 'stable') && (github.event_name != 'pull_request')
     name: Test pulling the image on arm64
     needs: [build-arm64, create-multi-arch-manifest]
     runs-on: self-hosted-generic-arm64
@@ -246,7 +246,7 @@ jobs:
         run: docker pull registry.community.greenbone.net/${{ inputs.image-url }}:latest
 
   test-pull-amd64:
-    if: inputs.base-image-label == 'stable'
+    if: (steps.latest.outputs.is-latest-tag == 'true') && (inputs. inputs.base-image-label == 'stable') && (github.event_name != 'pull_request')
     name: Test pulling the image on amd64
     needs: [build-amd64, create-multi-arch-manifest]
     runs-on: self-hosted-generic

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -120,22 +120,7 @@ jobs:
             IMAGE_REGISTRY=${{ vars.IMAGE_REGISTRY }}
           image-url: ${{ inputs.image-url }}
           image-labels: ${{ inputs.image-labels }}
-          image-tags: |
-            type=semver,pattern={{version}},value=${{ inputs.ref-name }},enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=semver,pattern={{version}},enable=${{ github.event_name != 'workflow_dispatch' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.ref-name }},enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name != 'workflow_dispatch' }}
-            type=semver,pattern={{major}},value=${{ inputs.ref-name }},enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=semver,pattern={{major}},enable=${{ github.event_name != 'workflow_dispatch' }}
-            type=edge
-            type=ref,event=pr
-            type=raw,value=latest,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'stable') }}
-            type=raw,value=stable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'stable') }}
-            type=raw,value=edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'stable') }}
-            type=raw,value=oldstable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'oldstable') }}
-            type=raw,value=oldstable-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'oldstable') }}
-            type=raw,value=testing,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'testing') }}
-            type=raw,value=testing-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'testing') }}
+          image-tags: type=raw,value=${{ inputs.ref_name }} # temporary tag that will be overwritten with the manifest upload
           image-platforms: linux/amd64
           registry: ${{ secrets.GREENBONE_REGISTRY }}
           registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}
@@ -196,22 +181,7 @@ jobs:
             IMAGE_REGISTRY=${{ vars.IMAGE_REGISTRY }}
           image-url: ${{ inputs.image-url }}
           image-labels: ${{ inputs.image-labels }}
-          image-tags: |
-            type=semver,pattern={{version}},value=${{ inputs.ref-name }},enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=semver,pattern={{version}},enable=${{ github.event_name != 'workflow_dispatch' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.ref-name }},enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name != 'workflow_dispatch' }}
-            type=semver,pattern={{major}},value=${{ inputs.ref-name }},enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=semver,pattern={{major}},enable=${{ github.event_name != 'workflow_dispatch' }}
-            type=edge
-            type=ref,event=pr
-            type=raw,value=latest,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'stable') }}
-            type=raw,value=stable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'stable') }}
-            type=raw,value=edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'stable') }}
-            type=raw,value=oldstable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'oldstable') }}
-            type=raw,value=oldstable-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'oldstable') }}
-            type=raw,value=testing,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'testing') }}
-            type=raw,value=testing-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'testing') }}
+          image-tags: type=raw,value=${{ inputs.ref_name }} # temporary tag that will be overwritten with the manifest upload
           image-platforms: linux/arm64
           registry: ${{ secrets.GREENBONE_REGISTRY }}
           registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}
@@ -227,6 +197,28 @@ jobs:
       - build-amd64
       - build-arm64
     steps:
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.image-url }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.ref-name }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.ref-name }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=semver,pattern={{major}},value=${{ inputs.ref-name }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=semver,pattern={{major}},enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=edge
+            type=ref,event=pr
+            type=raw,value=latest,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'stable') }}
+            type=raw,value=stable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'stable') }}
+            type=raw,value=edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'stable') }}
+            type=raw,value=oldstable,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'oldstable') }}
+            type=raw,value=oldstable-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'oldstable') }}
+            type=raw,value=testing,enable=${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs.base-image-label == 'testing') }}
+            type=raw,value=testing-edge,enable=${{ ((inputs.ref-name || github.ref_name) == 'main') && (inputs.base-image-label == 'testing') }}
+
       - name: Create multi arch manifest
         uses: greenbone/actions/container-multi-arch-manifest@v3
         with:
@@ -236,9 +228,7 @@ jobs:
           annotations: |
             ${{ needs.build-amd64.outputs.annotations }}
             ${{ needs.build-arm64.outputs.annotations }}
-          tags: |
-            ${{ needs.build-amd64.outputs.tags }}
-            ${{ needs.build-arm64.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           digests: |
             ${{ needs.build-amd64.outputs.digest }}
             ${{ needs.build-arm64.outputs.digest }}

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -195,7 +195,7 @@ jobs:
     steps:
       - name: Generate Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: ${{ inputs.image-url }}
           tags: |

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -69,6 +69,7 @@ jobs:
       digest: ${{ steps.build-and-push.outputs.digest }}
       tags: ${{ steps.build-and-push.outputs.tags }}
       annotations: ${{ steps.build-and-push.outputs.annotations }}
+      is-latest-tag: ${{ steps.latest.outputs.is-latest-tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -134,6 +135,7 @@ jobs:
       digest: ${{ steps.build-and-push.outputs.digest }}
       tags: ${{ steps.build-and-push.outputs.tags }}
       annotations: ${{ steps.build-and-push.outputs.annotations }}
+      is-latest-tag: ${{ steps.latest.outputs.is-latest-tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -237,7 +239,7 @@ jobs:
           registry-password: ${{ secrets.GREENBONE_REGISTRY_TOKEN }}
 
   test-pull-arm64:
-    if: ${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs. inputs.base-image-label == 'stable') && (github.event_name != 'pull_request') }}
+    if: ${{ (jobs.build-arm64.outputs.is-latest-tag == 'true') && (inputs. inputs.base-image-label == 'stable') && (github.event_name != 'pull_request') }}
     name: Test pulling the image on arm64
     needs: [build-arm64, create-multi-arch-manifest]
     runs-on: self-hosted-generic-arm64
@@ -246,7 +248,7 @@ jobs:
         run: docker pull registry.community.greenbone.net/${{ inputs.image-url }}:latest
 
   test-pull-amd64:
-    if: ${{ (steps.latest.outputs.is-latest-tag == 'true') && (inputs. inputs.base-image-label == 'stable') && (github.event_name != 'pull_request') }}
+    if: ${{ (jobs.build-amd64.outputs.is-latest-tag == 'true') && (inputs. inputs.base-image-label == 'stable') && (github.event_name != 'pull_request') }}
     name: Test pulling the image on amd64
     needs: [build-amd64, create-multi-arch-manifest]
     runs-on: self-hosted-generic


### PR DESCRIPTION
## What

Add ~~image-type~~ base-image-label as input for container-build-push-2nd-gen workflow.
The ~~image-type~~ base-image-label is an enum with the following possible values:
- stable
- oldstable
- testing

According to the set value the image-tags are enabled.

## Why

We wanted to merge the container.yml and push.yml workflows in gvm-libs.
The legacy workflow builds additional gvm-libs containers with oldstable and testing tags.
To represent this logic we need to parametrize the container-build-push-2nd-gen workflow somehow.

## References

https://jira.greenbone.net/browse/DEVOPS-1230

This is the PR requiring the changes: https://github.com/greenbone/gvm-libs/pull/838

## Test is here:

https://github.com/greenbone/pipeline-experiments/actions/workflows/test-container-build-push-2nd-gen.yml
