### PR TITLE
Fix: Fix by removing startWith(github.ref ...) condition

### DIFF
--- a/.github/workflows/container-build-push-feed.yml
+++ b/.github/workflows/container-build-push-feed.yml
@@ -203,7 +203,7 @@ jobs:
       - create-multi-arch-manifest
       - test-pull-amd64
       - test-pull-arm64
-    if: ${{ always() && startsWith(github.ref, 'refs/tags/v')  && startsWith(inputs.notify, 'true') }}
+    if: ${{ always() && startsWith(inputs.notify, 'true') }}
     uses: greenbone/workflows/.github/workflows/notify-mattermost-2nd-gen.yml@main
     with:
       status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}


### PR DESCRIPTION
## What

Notify job in cert-bund-data and scap-data is failing

## Why

startWith(github.ref ...) doesn't allow for anything other than version tags.

## References

https://jira.greenbone.net/browse/DEVOPS-1225



