### PR TITLE
Fix: Feed notification

### DIFF
--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -41,7 +41,7 @@ on:
       notification-channel:
         description: "The name of the channel where the notification happens."
         type: string
-        default: "todfeeddeploymentnotification"
+        default: "pd2ndgendeployment"
 
     secrets:
       COSIGN_KEY_OPENSIGHT:

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -38,6 +38,10 @@ on:
         description: "The artifact path to extract the artifact into."
         required: false
         type: string
+      notification-channel:
+        description: "The name of the channel where the notification happens."
+        type: string
+        default: "pd2ndgendeployment"
 
     secrets:
       COSIGN_KEY_OPENSIGHT:
@@ -257,4 +261,5 @@ jobs:
     uses: greenbone/workflows/.github/workflows/notify-mattermost-2nd-gen.yml@main
     with:
       status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+      channel: ${{ inputs.notification-channel }}
     secrets: inherit

--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -41,7 +41,7 @@ on:
       notification-channel:
         description: "The name of the channel where the notification happens."
         type: string
-        default: "pd2ndgendeployment"
+        default: "todfeeddeploymentnotification"
 
     secrets:
       COSIGN_KEY_OPENSIGHT:

--- a/.github/workflows/container-build-push-feed.yml
+++ b/.github/workflows/container-build-push-feed.yml
@@ -42,6 +42,10 @@ on:
         description: "Is this the vts image?"
         default: "false"
         type: string
+      notification-channel:
+        description: "The name of the channel where the notification happens."
+        type: string
+        default: "pd2ndgendeployment"
 
     secrets:
       COSIGN_KEY_OPENSIGHT:
@@ -207,4 +211,5 @@ jobs:
     uses: greenbone/workflows/.github/workflows/notify-mattermost-2nd-gen.yml@main
     with:
       status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+      channel: ${{ inputs.notification-channel }}
     secrets: inherit

--- a/.github/workflows/container-build-push-feed.yml
+++ b/.github/workflows/container-build-push-feed.yml
@@ -199,3 +199,17 @@ jobs:
     steps:
       - name: Pull
         run: docker pull registry.community.greenbone.net/${{ inputs.image-url }}:latest
+
+  notify:
+    needs:
+      - build-amd64
+      - build-arm64
+      - create-multi-arch-manifest
+      - test-pull-amd64
+      - test-pull-arm64
+    if: ${{ always() && startsWith(inputs.notify, 'true') }}
+    uses: greenbone/workflows/.github/workflows/notify-mattermost-2nd-gen.yml@main
+    with:
+      status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+      channel: ${{ inputs.notification-channel }}
+    secrets: inherit

--- a/.github/workflows/container-build-push-feed.yml
+++ b/.github/workflows/container-build-push-feed.yml
@@ -45,7 +45,7 @@ on:
       notification-channel:
         description: "The name of the channel where the notification happens."
         type: string
-        default: "pdfeeddeploymentnotification"
+        default: "toddevopsgithubstatusnotification"
 
     secrets:
       COSIGN_KEY_OPENSIGHT:

--- a/.github/workflows/container-build-push-feed.yml
+++ b/.github/workflows/container-build-push-feed.yml
@@ -199,17 +199,3 @@ jobs:
     steps:
       - name: Pull
         run: docker pull registry.community.greenbone.net/${{ inputs.image-url }}:latest
-
-  notify:
-    needs:
-      - build-amd64
-      - build-arm64
-      - create-multi-arch-manifest
-      - test-pull-amd64
-      - test-pull-arm64
-    if: ${{ always() && startsWith(inputs.notify, 'true') }}
-    uses: greenbone/workflows/.github/workflows/notify-mattermost-2nd-gen.yml@main
-    with:
-      status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
-      channel: ${{ inputs.notification-channel }}
-    secrets: inherit

--- a/.github/workflows/container-build-push-feed.yml
+++ b/.github/workflows/container-build-push-feed.yml
@@ -45,7 +45,7 @@ on:
       notification-channel:
         description: "The name of the channel where the notification happens."
         type: string
-        default: "todfeeddeploymentnotification"
+        default: "pdfeeddeploymentnotification"
 
     secrets:
       COSIGN_KEY_OPENSIGHT:

--- a/.github/workflows/container-build-push-feed.yml
+++ b/.github/workflows/container-build-push-feed.yml
@@ -45,7 +45,7 @@ on:
       notification-channel:
         description: "The name of the channel where the notification happens."
         type: string
-        default: "pd2ndgendeployment"
+        default: "todfeeddeploymentnotification"
 
     secrets:
       COSIGN_KEY_OPENSIGHT:

--- a/.github/workflows/container-build-push-feed.yml
+++ b/.github/workflows/container-build-push-feed.yml
@@ -45,7 +45,7 @@ on:
       notification-channel:
         description: "The name of the channel where the notification happens."
         type: string
-        default: "toddevopsgithubstatusnotification"
+        default: "pdfeeddeploymentnotification"
 
     secrets:
       COSIGN_KEY_OPENSIGHT:

--- a/.github/workflows/helm-container-build-push-3rd-gen.yml
+++ b/.github/workflows/helm-container-build-push-3rd-gen.yml
@@ -248,7 +248,7 @@ jobs:
       - building-service-chart
       - building-product-chart
       - building-product-compose
-    if: ${{ !cancelled() && startsWith(github.ref, 'refs/tags/v')  && startsWith(inputs.notify, 'true') }}
+    if: ${{ !cancelled()  && startsWith(inputs.notify, 'true') }}
     uses: greenbone/workflows/.github/workflows/notify-mattermost-3rd-gen.yml@main
     with:
       status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}

--- a/.github/workflows/notify-mattermost-2nd-gen.yml
+++ b/.github/workflows/notify-mattermost-2nd-gen.yml
@@ -19,6 +19,10 @@ on:
         description: "The monitored job, job status."
         type: string
         required: true
+      channel:
+        description: "The name of the channel where the notification happens."
+        type: string
+        default: "pd2ndgendeployment"
     # Dependabot don't have this secrets and on PR's this secrets are not needed.
     secrets:
       MATTERMOST_WEBHOOK_URL:
@@ -33,7 +37,7 @@ jobs:
         uses: greenbone/actions/mattermost-notify@v3
         with:
           url: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-          channel: "todfeeddeploymentnotification"
+          channel: ${{ inputs.channel }}
           highlight: ${{ inputs.highlight }}
           branch: ${{ github.ref_name }}
           commit: ${{ inputs.commit }}

--- a/.github/workflows/notify-mattermost-2nd-gen.yml
+++ b/.github/workflows/notify-mattermost-2nd-gen.yml
@@ -22,7 +22,7 @@ on:
       channel:
         description: "The name of the channel where the notification happens."
         type: string
-        default: "pd2ndgendeployment"
+        required: true
     # Dependabot don't have this secrets and on PR's this secrets are not needed.
     secrets:
       MATTERMOST_WEBHOOK_URL:

--- a/.github/workflows/notify-mattermost-2nd-gen.yml
+++ b/.github/workflows/notify-mattermost-2nd-gen.yml
@@ -22,7 +22,7 @@ on:
       channel:
         description: "The name of the channel where the notification happens."
         type: string
-        required: true
+        default: pd2ndgendeployment
     # Dependabot don't have this secrets and on PR's this secrets are not needed.
     secrets:
       MATTERMOST_WEBHOOK_URL:

--- a/.github/workflows/notify-mattermost-2nd-gen.yml
+++ b/.github/workflows/notify-mattermost-2nd-gen.yml
@@ -33,7 +33,7 @@ jobs:
         uses: greenbone/actions/mattermost-notify@v3
         with:
           url: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-          channel: "pd2ndgendeployment"
+          channel: "todfeeddeploymentnotification"
           highlight: ${{ inputs.highlight }}
           branch: ${{ github.ref_name }}
           commit: ${{ inputs.commit }}


### PR DESCRIPTION
## What

Change notification-channel for notify-mattermost-2nd-gen.yml
Adapt if conditions when using notify-mattermost* workflows

## Why

Currently https://github.com/greenbone/workflows/blob/main/.github/workflows/notify-mattermost-2nd-gen.yml#L36 notifies in channel: [PD:2ndGenDeployment](https://mattermost.greenbone.net/gb/channels/pd2ndgendeployment) but should be [TOD:FeedDeployment:Notification](https://mattermost.greenbone.net/gb/channels/pdfeeddeploymentnotification) 

Also check and adapt the if conditions for all workflows in greenbone/workflows using the notify-mattermost-2nd.gen workflow -> They should be run on every build.

## References

https://jira.greenbone.net/browse/DEVOPS-1254



