### PR TITLE
Add: missing building-container dep in helm-container-build-push-3rd-gen.yml

### DIFF
--- a/.github/workflows/helm-container-build-push-3rd-gen.yml
+++ b/.github/workflows/helm-container-build-push-3rd-gen.yml
@@ -233,6 +233,7 @@ jobs:
   building-product-compose:
     if: (inputs.helm-chart) && (startsWith(github.ref, 'refs/tags/v'))
     needs:
+      - building-container
       - building-container-greenbone-reg
     runs-on: "ubuntu-latest"
     steps:


### PR DESCRIPTION
## What
Add: missing building-container dep in helm-container-build-push-3rd-gen.yml
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
building-container job dependency is required to get the container digest for the compose upgrade.
<!-- Describe why are these changes necessary? -->

## References
None



