### PR TITLE
Add notify-mattermost-cloud-dependapot-pr.yml for cloud team.

### DIFF
--- a/.github/workflows/notify-mattermost-cloud-dependapot-pr.yml
+++ b/.github/workflows/notify-mattermost-cloud-dependapot-pr.yml
@@ -1,0 +1,65 @@
+name: Notify Mattermost Cloud Team
+
+on:
+  workflow_call:
+    inputs:
+      commit:
+        description: "The commit used by the github checkout action. Default: github.sha"
+        type: string
+        default: ${{ github.sha }}
+      exit-with-status:
+        description: "Exit this job/workflow with the monitored job status. Options: true or false. Default: true"
+        type: string
+        default: "true"
+      highlight:
+        description: "Mattermost highlight. Default: pdcloudtestalerts"
+        type: string
+        default: "pdcloudtestalerts"
+      status:
+        description: "The monitored job, job status."
+        type: string
+        required: true
+    # Dependabot don't have this secrets and on PR's this secrets are not needed.
+    secrets:
+      MATTERMOST_WEBHOOK_URL:
+        required: false
+
+jobs:
+  check-old-dependabot-prs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch old Dependabot PRs
+        id: fetch_prs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}
+        run: |
+          SEVEN_DAYS_AGO=$(date -d '7 days ago' +%s)
+          gh pr list --label "dependencies" --state "open" --json url,createdAt,title > all_dependabot_prs.json
+          
+          OLD_PRS=$(cat all_dependabot_prs.json | jq --argjson cutoff "$SEVEN_DAYS_AGO" \
+            '.[] | select((.createdAt | fromdateiso8601) < $cutoff)')
+
+          if [[ -z "$OLD_PRS" ]]; then
+            echo "OLD_PRS_FOUND=false" >> $GITHUB_ENV
+          else
+            echo "$OLD_PRS" | jq -r '. | "- **\(.title)**: [View PR](\(.url))"' > old_pr_list.txt
+            echo "OLD_PRS_FOUND=true" >> $GITHUB_ENV
+            echo "MESSAGE_TEXT=$(<old_pr_list.txt)" >> $GITHUB_ENV
+
+      - name: Notify Mattermost
+        if: env.OLD_PRS_FOUND == 'true'
+        uses: greenbone/actions/mattermost-notify@v3
+        with:
+          url: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          channel: "pdcloudtestalerts"
+          message: ${{ env.MESSAGE_TEXT }}
+          repository: ${{ github.repository }}
+          commit: ${{ github.sha }}
+          branch: ${{ github.ref_name }}
+          status: "success"
+          workflow: ${{ github.run_id }}
+          workflow-name: ${{ github.workflow }}


### PR DESCRIPTION
## What

CI pipeline script for non-merged dependabot pull requests -> alarm in Mattermost (7 days) 

## Why

We initially set up automatic merging for all Dependabot PRs if they passed the tests. However, some PRs require code changes by the team. This CI pipeline will alert the team if a PR hasn't been merged within 7 days.

## References

https://jira.greenbone.net/browse/GCS-1107



