### PR TITLE
CI: Use short status notification

### DIFF
--- a/.github/workflows/notify-mattermost-feed-deployment.yml
+++ b/.github/workflows/notify-mattermost-feed-deployment.yml
@@ -33,7 +33,7 @@ jobs:
     if: ${{ !cancelled() }}
     steps:
       - name: Notify Mattermost Feed Deployment
-        uses: greenbone/actions/mattermost-notify@a1883bd24d2d921426b3f06413e84606ecd43bdd # v3.27.11
+        uses: greenbone/actions/mattermost-notify@45b6e84c655954002872d0ac6c8d31b2f213c9a0 # v3.27.17
         with:
           url: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
           channel: ${{ secrets.MATTERMOST_FEED_CHANNEL }}
@@ -43,6 +43,7 @@ jobs:
           workflow: ${{ github.run_id }}
           workflow-name: ${{ github.workflow }}
           status: ${{ inputs.status }}
+          shortline: "true"
       - name: Exit with monitored job status
         if: inputs.exit-with-status == 'true' && inputs.status != 'success'
         run: |


### PR DESCRIPTION
## What
Updated feed update CI to use single line status notifications

## Why
Multi-Line notifications are using up a lot of space, and it is easier to see the current state and
recent trends if every status update just consists of a single line

