### PR TITLE
Fix add GREENBONE_BOT_TOKEN as a secret when not able to inherit

### DIFF
--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -61,6 +61,8 @@ on:
         required: false
       GREENBONE_REGISTRY_TOKEN:
         required: false
+      GREENBONE_BOT_TOKEN:
+        required: false
       GREENBONE_REGISTRY_REPLICATION_USER:
         required: false
       GREENBONE_REGISTRY_REPLICATION_TOKEN:


### PR DESCRIPTION
This adds GREENBONE_BOT_TOKEN as a workflow secret so that build pipelines that don't rely on inheritance are able to functions by providing it manually.

To fix: https://github.com/greenbone/openvas-scanner/actions/runs/12350274906/workflow
