### PR TITLE
 Allow to specify a format checking tool for python linting workflow

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -14,6 +14,10 @@ on:
         description: "Linter to use: Default is 'pylint'."
         default: "pylint"
         type: string
+      formatter:
+        description: "Format check to use: Default is 'black --check --diff'."
+        default: "black --check --diff"
+        type: string
 
 jobs:
   linting:
@@ -27,3 +31,4 @@ jobs:
           packages: ${{ inputs.lint-packages }}
           python-version: ${{ inputs.python-version }}
           linter: ${{ inputs.linter }}
+          formatter: ${{ inputs.formatter }}


### PR DESCRIPTION



## What

 Allow to specify a format checking tool for python linting workflow


## Why
Besides black there is ruff format, which is much faster.

## References

Requires https://github.com/greenbone/actions/pull/1325
