### PR TITLE
Add: shortline support for notify mattermost workflows

### DIFF
--- a/.github/workflows/notify-mattermost-2nd-gen.yml
+++ b/.github/workflows/notify-mattermost-2nd-gen.yml
@@ -23,6 +23,10 @@ on:
         description: "The name of the channel where the notification happens."
         type: string
         default: pd2ndgendeployment
+      shortline:
+        description: "Mattermost use shortline mode. Default: true"
+        type: string
+        default: "true"
     # Dependabot don't have this secrets and on PR's this secrets are not needed.
     secrets:
       MATTERMOST_WEBHOOK_URL:
@@ -44,6 +48,8 @@ jobs:
           workflow: ${{ github.run_id }}
           workflow-name: ${{ github.workflow }}
           status: ${{ inputs.status }}
+          shortline: ${{ inputs.highlight }}
+
       - name: Exit with monitored job status
         if: inputs.exit-with-status == 'true' && inputs.status != 'success'
         run: |

--- a/.github/workflows/notify-mattermost-3rd-gen-ci.yml
+++ b/.github/workflows/notify-mattermost-3rd-gen-ci.yml
@@ -19,6 +19,10 @@ on:
         description: "The monitored job, job status."
         type: string
         required: true
+      shortline:
+        description: "Mattermost use shortline mode. Default: true"
+        type: string
+        default: "true"
     # Dependabot don't have this secrets and on PR's this secrets are not needed.
     secrets:
       MATTERMOST_WEBHOOK_URL:
@@ -42,6 +46,8 @@ jobs:
           workflow: ${{ github.run_id }}
           workflow-name: ${{ github.workflow }}
           status: ${{ inputs.status }}
+          shortline: ${{ inputs.highlight }}
+
       - name: Exit with monitored job status
         if: inputs.exit-with-status == 'true' && inputs.status != 'success'
         run: |

--- a/.github/workflows/notify-mattermost-3rd-gen.yml
+++ b/.github/workflows/notify-mattermost-3rd-gen.yml
@@ -19,6 +19,10 @@ on:
         description: "The monitored job, job status."
         type: string
         required: true
+      shortline:
+        description: "Mattermost use shortline mode. Default: true"
+        type: string
+        default: "true"
     # Dependabot don't have this secrets and on PR's this secrets are not needed.
     secrets:
       MATTERMOST_WEBHOOK_URL:
@@ -42,6 +46,8 @@ jobs:
           workflow: ${{ github.run_id }}
           workflow-name: ${{ github.workflow }}
           status: ${{ inputs.status }}
+          shortline: ${{ inputs.highlight }}
+
       - name: Exit with monitored job status
         if: inputs.exit-with-status == 'true' && inputs.status != 'success'
         run: |

--- a/.github/workflows/notify-mattermost-feed-deployment.yml
+++ b/.github/workflows/notify-mattermost-feed-deployment.yml
@@ -19,6 +19,10 @@ on:
         description: "The monitored job, job status."
         type: string
         required: true
+      shortline:
+        description: "Mattermost use shortline mode. Default: true"
+        type: string
+        default: "true"
     secrets:
       MATTERMOST_WEBHOOK_URL:
         required: true
@@ -43,7 +47,8 @@ jobs:
           workflow: ${{ github.run_id }}
           workflow-name: ${{ github.workflow }}
           status: ${{ inputs.status }}
-          shortline: "true"
+          shortline: ${{ inputs.highlight }}
+
       - name: Exit with monitored job status
         if: inputs.exit-with-status == 'true' && inputs.status != 'success'
         run: |

--- a/.github/workflows/notify-mattermost-qm.yml
+++ b/.github/workflows/notify-mattermost-qm.yml
@@ -19,6 +19,10 @@ on:
         description: "The monitored job, job status."
         type: string
         required: true
+      shortline:
+        description: "Mattermost use shortline mode. Default: true"
+        type: string
+        default: "true"
     # Dependabot don't have this secrets and on PR's this secrets are not needed.
     secrets:
       MATTERMOST_WEBHOOK_URL:
@@ -42,6 +46,8 @@ jobs:
           workflow: ${{ github.run_id }}
           workflow-name: ${{ github.workflow }}
           status: ${{ inputs.status }}
+          shortline: ${{ inputs.highlight }}
+
       - name: Exit with monitored job status
         if: inputs.exit-with-status == 'true' && inputs.status != 'success'
         run: |


### PR DESCRIPTION
## What
Add: shortline support for notify mattermost workflows
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
With this change we can disable/enable default is enable the shortline mode in every workflow.
For example here it is already used, but this input option never existed. https://github.com/greenbone/greenbone-docker/actions/runs/13362015979/workflow#L146 
<!-- Describe why are these changes necessary? -->

## References
None



