### PR TITLE
Add a workflow for building container images for GEA components

### DIFF
--- a/.github/workflows/container-build-push-gea.yml
+++ b/.github/workflows/container-build-push-gea.yml
@@ -1,4 +1,4 @@
-name: GEA Components Container Image Build and Push
+name: OPENVAS SCAN Components Container Image Build and Push
 
 on:
   workflow_call:


### PR DESCRIPTION


## What

Add a workflow for building container images for GEA components

## Why

This new workflow can be used to build container images for GEA components with different features enabled. It is more flexible compared to the 2nd gen workflow. It is just intended to build and upload the images for amd64 and arch64. It leaves out the signatures (for now) and the notifications.

The workflow sets sane defaults for every input parameter and tries to be flexible as possible. It uploads all images to our greenbone container registry and ghcr.io. ghcr.io also gets images build from pull requests.

## References
https://jira.greenbone.net/browse/GEA-1139


