### PR TITLE
Change: Add openvas-detect-dev URL to container

### DIFF
--- a/.github/workflows/container-build-push-2nd-gen.yml
+++ b/.github/workflows/container-build-push-2nd-gen.yml
@@ -277,7 +277,7 @@ jobs:
 
       - name: Create multi arch manifest
         id: manifest
-        uses: greenbone/actions/container-multi-arch-manifest@pascalholthaus-patch-1
+        uses: greenbone/actions/container-multi-arch-manifest@v3
         with:
           cosign-key: ${{ secrets.COSIGN_KEY_OPENSIGHT }}
           cosign-key-password: ${{ secrets.COSIGN_KEY_PASSWORD_OPENSIGHT }}


### PR DESCRIPTION
## What

- Change all container URLs from community and  opensight-sensor-dev  to openvas-detect-dev in workflow steps.

## Why

- Standardizes image registry paths per new convention.
https://github.com/greenbone/actions/pull/1465
## References

- [DEVOPS-1681](https://jira.greenbone.net/browse/DEVOPS-1681)