### PR TITLE
Add(3rdgen): unstable-release tags for release branch image builds

### DIFF
--- a/.github/workflows/container-build-push-3rd-gen.yml
+++ b/.github/workflows/container-build-push-3rd-gen.yml
@@ -119,6 +119,8 @@ jobs:
             type=ref,event=pr
             # use unstable for main branch
             type=raw,value=unstable,enable={{is_default_branch}}
+            # use unstable-release for release branch
+            type=raw,value=unstable-release,enable=${{startsWith(github.ref, 'refs/heads/release-v')}}
           image-platforms: ${{ inputs.image-platforms }}
           registry: ${{ vars.IMAGE_REGISTRY }}
           registry-username: ${{ github.actor }}
@@ -205,6 +207,8 @@ jobs:
             type=ref,event=pr
             # use unstable for main branch
             type=raw,value=unstable,enable={{is_default_branch}}
+            # use unstable-release for release branch
+            type=raw,value=unstable-release,enable=${{startsWith(github.ref, 'refs/heads/release-v')}}
           registry: ${{ vars.GREENBONE_REGISTRY }}
           registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}
           registry-password: ${{ secrets.GREENBONE_REGISTRY_TOKEN }}


### PR DESCRIPTION
## What

Add unstable-release tags for release branch image builds.

## Why

This is needed to have a tag available after a merge to a release branch from a hotfix branch. Currently the workflow fails, because it can not determine a proper flag.

## References

DOS-421
T5-1642


