### PR TITLE
Change(3rdgen): Update release branch filter for unstable tag

### DIFF
--- a/.github/workflows/container-build-push-3rd-gen.yml
+++ b/.github/workflows/container-build-push-3rd-gen.yml
@@ -119,8 +119,8 @@ jobs:
             type=ref,event=pr
             # use unstable for main branch
             type=raw,value=unstable,enable={{is_default_branch}}
-            # use unstable-release for release branch
-            type=raw,value=unstable-release,enable=${{startsWith(github.ref, 'refs/heads/release-v')}}
+            # use unstable-release for release branches
+            type=raw,value=unstable-release,enable=${{startsWith(github.ref, 'refs/heads/release/')}}
           image-platforms: ${{ inputs.image-platforms }}
           registry: ${{ vars.IMAGE_REGISTRY }}
           registry-username: ${{ github.actor }}
@@ -207,8 +207,8 @@ jobs:
             type=ref,event=pr
             # use unstable for main branch
             type=raw,value=unstable,enable={{is_default_branch}}
-            # use unstable-release for release branch
-            type=raw,value=unstable-release,enable=${{startsWith(github.ref, 'refs/heads/release-v')}}
+            # use unstable-release for release branches
+            type=raw,value=unstable-release,enable=${{startsWith(github.ref, 'refs/heads/release/')}}
           registry: ${{ vars.GREENBONE_REGISTRY }}
           registry-username: ${{ secrets.GREENBONE_REGISTRY_USER }}
           registry-password: ${{ secrets.GREENBONE_REGISTRY_TOKEN }}


### PR DESCRIPTION
## What

Using release branch names like `release/vX.X.X` is more natural to github than `release-vX.X.X`.

## References

DOS-421

