### PR TITLE
Add: trigger for osi

### DIFF
--- a/.github/workflows/container-build-push-3rd-gen.yml
+++ b/.github/workflows/container-build-push-3rd-gen.yml
@@ -265,8 +265,8 @@ jobs:
 
       - name: Trigger security security-intelligence compose upgrade
         if: |
-          inputs.service == 'asset-management-backend' ||
-          inputs.service == 'vulnerability-intelligence' ||
+          startsWith(inputs.service, 'asset-management-') ||
+          startsWith(inputs.service, 'vulnerability-intelligence-') ||
           inputs.service == 'management-console' ||
           inputs.service == 'user-management' ||
           inputs.service == 'opensearch' ||


### PR DESCRIPTION
## What

Trigger automatix with service: security-intelligence when osi components release.

## Why

Keep OSI updated automatically.

## References

[DEVOPS-1722](https://jira.greenbone.net/browse/DEVOPS-1722)

## Checklist

- [ ] Tests


