### PR TITLE
Don't push GEA edge images to the Greenbone container registry

### DIFF
--- a/.github/workflows/container-build-push-gea.yml
+++ b/.github/workflows/container-build-push-gea.yml
@@ -48,7 +48,7 @@ on:
         required: false
         default: |
           ghcr.io/${{ github.repository }},enable=true
-          ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' }}
+          ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' && github.ref_type == 'tag' }}
       annotation-levels:
         description: |
           "The levels to apply the annotations to. ghcr.io only supports index "


### PR DESCRIPTION


## What

Don't push GEA edge images to the Greenbone container registry

## Why



The edge images should not be used by the community or any enterprise product. Their only purpose is for testing.

## References

https://jira.greenbone.net/browse/DOS-661


